### PR TITLE
fix: Add missing string.h import in winfsp_fuse.h

### DIFF
--- a/Contributors.asciidoc
+++ b/Contributors.asciidoc
@@ -67,6 +67,7 @@ CONTRIBUTOR LIST
 |John Oberschelp                                                |john at oberschelp.net
 |John Tyner                                                     |jtyner at gmail.com
 |Konstantinos Karakostas                                        |noiredev at protonmail.com
+|Naoki Ikeguchi                                                 |me at s6n.jp
 |Paweł Wegner (Google LLC, https://google.com)                  |lemourin at google.com
 |Pedro Frejo (Arpa System, https://arpasystem.com)              |pedro.frejo at arpasystem.com
 |Ronny Chan                                                     |ronny at ronnychan.ca

--- a/inc/fuse/winfsp_fuse.h
+++ b/inc/fuse/winfsp_fuse.h
@@ -27,6 +27,7 @@
 #include <stdint.h>
 #if !defined(WINFSP_DLL_INTERNAL)
 #include <stdlib.h>
+#include <string.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
`memset()` [is called from winfsp_fuse.h](https://github.com/winfsp/winfsp/blob/b058925692e8847e20cda6f711a23c0fa5131bf6/inc/fuse/winfsp_fuse.h#L366) but it's not imported so compiling with this header file will fail. This pull request adds the missing import directive.

----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [x] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
