### PR TITLE
sys & dll: Added FlushOnCleanup volume param

### DIFF
--- a/inc/winfsp/fsctl.h
+++ b/inc/winfsp/fsctl.h
@@ -250,7 +250,8 @@ enum
     UINT32 StreamInfoTimeout;           /* stream info timeout (millis); overrides FileInfoTimeout */\
     UINT32 EaTimeout;                   /* EA timeout (millis); overrides FileInfoTimeout */\
     UINT32 FsextControlCode;\
-    UINT32 Reserved32[1];\
+    UINT32 FlushOnCleanup:1;\
+    UINT32 Reserved32:31;\
     UINT64 Reserved64[2];
 typedef struct
 {

--- a/inc/winfsp/winfsp.hpp
+++ b/inc/winfsp/winfsp.hpp
@@ -620,6 +620,14 @@ public:
     {
         _VolumeParams.FlushAndPurgeOnCleanup = !!FlushAndPurgeOnCleanup;
     }
+    BOOLEAN FlushOnCleanup()
+    {
+        return _VolumeParams.FlushOnCleanup;
+    }
+    VOID SetFlushOnCleanup(BOOLEAN FlushOnCleanup)
+    {
+        _VolumeParams.FlushOnCleanup = !!FlushOnCleanup;
+    }
     PWSTR Prefix()
     {
         return _VolumeParams.Prefix;

--- a/src/dll/fuse/fuse.c
+++ b/src/dll/fuse/fuse.c
@@ -98,6 +98,7 @@ static struct fuse_opt fsp_fuse_core_opts[] =
     FSP_FUSE_CORE_OPT("VolumeInfoTimeout=", set_VolumeInfoTimeout, 1),
     FSP_FUSE_CORE_OPT("VolumeInfoTimeout=%d", VolumeParams.VolumeInfoTimeout, 0),
     FSP_FUSE_CORE_OPT("KeepFileCache=", set_KeepFileCache, 1),
+    FSP_FUSE_CORE_OPT("FlushOnCleanup=", set_FlushOnCleanup, 1),
     FSP_FUSE_CORE_OPT("LegacyUnlinkRename=", set_LegacyUnlinkRename, 1),
     FSP_FUSE_CORE_OPT("ThreadCount=%u", ThreadCount, 0),
     FUSE_OPT_KEY("UNC=", 'U'),
@@ -802,6 +803,7 @@ FSP_FUSE_API struct fuse *fsp_fuse_new(struct fsp_fuse_env *env,
     opt_data.VolumeParams.FileInfoTimeout = 1000;
     opt_data.VolumeParams.FlushAndPurgeOnCleanup = TRUE;
     opt_data.VolumeParams.SupportsPosixUnlinkRename = TRUE;
+    opt_data.VolumeParams.FlushOnCleanup = FALSE;
 
     if (-1 == fsp_fuse_core_opt_parse(env, args, &opt_data, /*help=*/1))
     {
@@ -871,6 +873,8 @@ FSP_FUSE_API struct fuse *fsp_fuse_new(struct fsp_fuse_env *env,
         opt_data.VolumeParams.VolumeInfoTimeoutValid = 1;
     if (opt_data.set_KeepFileCache)
         opt_data.VolumeParams.FlushAndPurgeOnCleanup = FALSE;
+    if (opt_data.set_FlushOnCleanup)
+        opt_data.VolumeParams.FlushOnCleanup = TRUE;
     if (opt_data.set_LegacyUnlinkRename)
         opt_data.VolumeParams.SupportsPosixUnlinkRename = FALSE;
     opt_data.VolumeParams.CaseSensitiveSearch = TRUE;

--- a/src/dll/fuse/fuse_intf.c
+++ b/src/dll/fuse/fuse_intf.c
@@ -1305,6 +1305,7 @@ static VOID fsp_fuse_intf_Cleanup(FSP_FILE_SYSTEM *FileSystem,
 {
     struct fuse *f = FileSystem->UserContext;
     struct fsp_fuse_file_desc *filedesc = FileDesc;
+    struct fuse_file_info fi;
 
     /*
      * In Windows a DeleteFile/RemoveDirectory is the sequence of the following:
@@ -1330,6 +1331,14 @@ static VOID fsp_fuse_intf_Cleanup(FSP_FILE_SYSTEM *FileSystem,
      * option, file systems that would need the hard_remove option can instead use the
      * LegacyUnlinkRename option to opt out of the POSIX unlink semantics.
      */
+
+    if (f->VolumeParams.FlushOnCleanup && !filedesc->IsDirectory && !filedesc->IsReparsePoint) {
+        memset(&fi, 0, sizeof fi);
+        fi.flags = filedesc->OpenFlags;
+        fi.fh = filedesc->FileHandle;
+        if (0 != f->ops.flush)
+            f->ops.flush(filedesc->PosixPath, &fi);
+    }
 
     if (Flags & FspCleanupDelete)
         if (filedesc->IsDirectory && !filedesc->IsReparsePoint)
@@ -1366,7 +1375,7 @@ static VOID fsp_fuse_intf_Close(FSP_FILE_SYSTEM *FileSystem,
     }
     else
     {
-        if (0 != f->ops.flush)
+        if (0 != f->ops.flush && !f->VolumeParams.FlushOnCleanup)
             f->ops.flush(filedesc->PosixPath, &fi);
         if (0 != f->ops.release)
             f->ops.release(filedesc->PosixPath, &fi);

--- a/src/dll/fuse/library.h
+++ b/src/dll/fuse/library.h
@@ -156,6 +156,7 @@ struct fsp_fuse_core_opt_data
         set_EaTimeout,
         set_VolumeInfoTimeout,
         set_KeepFileCache,
+        set_FlushOnCleanup,
         set_LegacyUnlinkRename;
     unsigned ThreadCount;
     FSP_FSCTL_VOLUME_PARAMS VolumeParams;

--- a/src/sys/cleanup.c
+++ b/src/sys/cleanup.c
@@ -134,6 +134,7 @@ static NTSTATUS FspFsvolCleanup(
         Request->Req.Cleanup.SetArchiveBit ||
         Request->Req.Cleanup.SetLastWriteTime ||
         Request->Req.Cleanup.SetChangeTime ||
+        FsvolDeviceExtension->VolumeParams.FlushOnCleanup ||
         !FsvolDeviceExtension->VolumeParams.PostCleanupWhenModifiedOnly)
         /*
          * Note that it is still possible for this request to not be delivered,


### PR DESCRIPTION
fix #605 

**Changes description (as discussed in the Issue):**

* Added a FlushOnCleanup volume parameter (I prefer **FlushOnCleanup** instead of **FlushOnClose** because it’s less confusing when reading the code). The default value is FALSE.
* In the FSD CLEANUP handler, if this parameter is enabled, the request will always be forwarded to the DLL.

**Discussion:**

* In the FUSE Flush [documentation](https://libfuse.github.io/doxygen/structfuse__lowlevel__ops.html?#ae69315421ba606590fed75353ec5d7ff) it says: ``` If this request is answered with an error code of ENOSYS, this is treated as success and future calls to flush() will succeed automatically without being sent to the filesystem process. ``` The current implementation doesn’t handle ENOSYS. I think that’s acceptable, since FUSE filesystems that don’t need flush can simply leave FlushOnCleanup disabled.
* Currently, if flush fails, we don’t handle the error at all. Maybe we should log something or call IoWriteErrorLogEntry?
* In the DLL cleanup path, when FlushOnCleanup is enabled, I placed the fuse flush call before all other procedures. I’m not sure whether calling flush is actually necessary for FspCleanupDelete. 

**Testing:**
* I ran the [patched](https://github.com/juicedata/winfsp/commit/6a822f066dbabb15059cd31da3262d2b0f8e82be) winfsp-tests (with tests unsupported by our filesystem commented out) against our filesystem. With FlushOnCleanup enabled and using the standard test command, all tests pass as FlushOnCleanup is disabled.

```
X:\>"C:\Program Files (x86)\WinFsp\bin\winfsp-tests-x64.exe" --fuse-external --resilient --case-insensitive-cmp -create_fileattr_test -create_readonlydir_test -getfileinfo_test -setfileinfo_test -delete_access_test -reparse_nfs_test
create_test............................ --- NtfsTests ---
OK 0.53s
create_related_test.................... OK 0.12s
create_sd_test......................... OK 0.23s
create_share_test...................... OK 0.24s
create_curdir_test..................... OK 0.00s
delete_test............................ OK 0.15s
delete_pending_test.................... OK 0.09s
delete_mmap_test....................... OK 0.06s
delete_standby_test.................... OK 0.66s
delete_ex_test......................... OK 0.00s
rename_test............................ OK 0.68s
rename_backslash_test.................. OK 0.21s
rename_open_test....................... OK 0.16s
rename_caseins_test.................... OK 0.22s
rename_flipflop_test................... OK 0.00s
rename_mmap_test....................... OK 0.24s
rename_standby_test.................... OK 2.74s
rename_ex_test......................... OK 0.30s
getvolinfo_test........................ OK 0.04s
setvolinfo_test........................ OK 0.00s
getsecurity_test....................... OK 0.09s
rdwr_noncached_test.................... OK 0.33s
rdwr_noncached_overlapped_test......... OK 0.33s
rdwr_cached_test....................... OK 0.31s
rdwr_cached_append_test................ OK 0.16s
rdwr_cached_overlapped_test............ OK 0.32s
rdwr_writethru_test.................... OK 0.33s
rdwr_writethru_append_test............. OK 0.13s
rdwr_writethru_overlapped_test......... OK 0.34s
rdwr_mmap_test......................... OK 1.60s
rdwr_mixed_test........................ OK 0.31s
flush_test............................. OK 1.30s
flush_volume_test...................... OK 0.00s
lock_noncached_test.................... OK 0.32s
lock_noncached_overlapped_test......... OK 0.30s
lock_cached_test....................... OK 0.30s
lock_cached_overlapped_test............ OK 0.34s
querydir_test.......................... OK 33.73s
querydir_expire_cache_test............. OK 0.00s
querydir_buffer_overflow_test.......... OK 0.07s
querydir_namelen_test.................. OK 0.00s
dirnotify_test......................... OK 1.26s
exec_test.............................. OK 0.36s
exec_delete_test....................... OK 1.27s
exec_rename_test....................... OK 1.32s
exec_rename_dir_test................... OK 2.51s
reparse_symlink_test................... OK 0.00s
reparse_symlink_relative_test.......... OK 0.00s
--- COMPLETE ---

X:\>
```

Thanks for reviewing. Please let me know if anything can be improved. 



----

Before submitting this PR please review this checklist. Ideally all checkmarks should be checked upon submitting. (Use an x inside square brackets like so: [x])

- [x] **Contributing**: You MUST read and be willing to accept the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc). The agreement gives joint copyright interests in your contributions to you and the original WinFsp author. If you have already accepted the [CONTRIBUTOR AGREEMENT](https://github.com/winfsp/winfsp/blob/master/Contributors.asciidoc) you do not need to do so again.
- [x] **Topic branch**: Avoid creating the PR off the master branch of your fork. Consider creating a topic branch and request a pull from that. This allows you to add commits to the master branch of your fork without affecting this PR.
- [x] **No tabs**: Consistently use SPACES everywhere. NO TABS, unless the file format requires it (e.g. Makefile).
- [x] **Style**: Follow the same code style as the rest of the project.
- [ ] **Tests**: Include tests to the extent that it is possible, especially if you add a new feature.
- [x] **Quality**: Your design and code should be of high quality and something that you are proud of.
